### PR TITLE
feat(utility):light green bg class

### DIFF
--- a/dist/typography.css
+++ b/dist/typography.css
@@ -171,6 +171,11 @@ we are keeping these classes in code base to support legacy code
   color: var(--secondaryClr130);
 }
 
+/* bg-color classes */
+
+.bgClrLightGreen{
+  background-color: var(--primaryClr10);
+}
 
 /* font weight */
 

--- a/dist/utility.css
+++ b/dist/utility.css
@@ -170,3 +170,7 @@ html[xmlns] .clearfix {
   color: var(--text130);
   margin: 0;
 }
+
+.bgClrLightGreen{
+  background-color: var(--primaryClr10);
+}

--- a/dist/utility.css
+++ b/dist/utility.css
@@ -170,7 +170,3 @@ html[xmlns] .clearfix {
   color: var(--text130);
   margin: 0;
 }
-
-.bgClrLightGreen{
-  background-color: var(--primaryClr10);
-}


### PR DESCRIPTION
We are pulling header out of components and will be keeping it in wrapper instead.
Earlier header used to have the same background color as that of the component in which it was in but now we have to provide the css class separately.
That is why created this class to directly pass in headerConfig for landing pages etc.